### PR TITLE
Add pthreads dependency to two targets

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ nthash = subproject('ntHash')
 nthash_dep = nthash.get_variable('lib_dep')
 include_dirs = [include_directories('include'), nthash.get_variable('include_dirs')]
 
-ptl = meson.get_compiler('cpp').find_library('pthread')
+thread_dep = dependency('threads')
 
 digest_lib = static_library(
 	'digest',
@@ -57,7 +57,7 @@ if get_option('buildtype') != 'release'
   executable(
    'bench',
    'tests/bench/benchmark.cpp',
-   dependencies : [bench, digest_dep, ptl],
+   dependencies : [bench, digest_dep, thread_dep],
   )
 
   ### benchmark data structures ###
@@ -85,7 +85,7 @@ if get_option('buildtype') != 'release'
   executable(
    'test_thread',
    'tests/test/test_thread.cpp',
-   dependencies : [catch2, digest_dep, ptl],
+   dependencies : [catch2, digest_dep, thread_dep],
   )
 
   doxygen = find_program('doxygen', required: false)

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ nthash = subproject('ntHash')
 nthash_dep = nthash.get_variable('lib_dep')
 include_dirs = [include_directories('include'), nthash.get_variable('include_dirs')]
 
+ptl = meson.get_compiler('cpp').find_library('pthread')
+
 digest_lib = static_library(
 	'digest',
 	include_directories: include_dirs,
@@ -55,7 +57,7 @@ if get_option('buildtype') != 'release'
   executable(
    'bench',
    'tests/bench/benchmark.cpp',
-   dependencies : [bench, digest_dep],
+   dependencies : [bench, digest_dep, ptl],
   )
 
   ### benchmark data structures ###
@@ -83,7 +85,7 @@ if get_option('buildtype') != 'release'
   executable(
    'test_thread',
    'tests/test/test_thread.cpp',
-   dependencies : [catch2, digest_dep],
+   dependencies : [catch2, digest_dep, ptl],
   )
 
   doxygen = find_program('doxygen', required: false)


### PR DESCRIPTION
My attempt to build with `meson setup --prefix=/code/install-root --buildtype=debug build` failed because of a couple targets not linking against pthreads.  I fixed that here by adding the pthreads library to the `meson.build` and adding the appropriate dependency to two targets.