### PR TITLE
Add <array> header include to data_structure.hpp

### DIFF
--- a/include/digest/data_structure.hpp
+++ b/include/digest/data_structure.hpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <utility>
 #include <vector>
+#include <array>
 
 // requirement on all data_structures
 // constructor which accepts uint32_t


### PR DESCRIPTION
Without this include, we fail to compile using g++ v12.