### PR TITLE
Fix semicolons in ds tests

### DIFF
--- a/include/digest/data_structure.hpp
+++ b/include/digest/data_structure.hpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <utility>
 #include <vector>
+#include <array>
 
 // requirement on all data_structures
 // constructor which accepts uint32_t

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ nthash = subproject('ntHash')
 nthash_dep = nthash.get_variable('lib_dep')
 include_dirs = [include_directories('include'), nthash.get_variable('include_dirs')]
 
+ptl = meson.get_compiler('cpp').find_library('pthread')
+
 digest_lib = static_library(
 	'digest',
 	include_directories: include_dirs,
@@ -55,7 +57,7 @@ if get_option('buildtype') != 'release'
   executable(
    'bench',
    'tests/bench/benchmark.cpp',
-   dependencies : [bench, digest_dep],
+   dependencies : [bench, digest_dep, ptl],
   )
 
   ### benchmark data structures ###
@@ -83,7 +85,7 @@ if get_option('buildtype') != 'release'
   executable(
    'test_thread',
    'tests/test/test_thread.cpp',
-   dependencies : [catch2, digest_dep],
+   dependencies : [catch2, digest_dep, ptl],
   )
 
   doxygen = find_program('doxygen', required: false)

--- a/tests/data_structure/bench_ds.cpp
+++ b/tests/data_structure/bench_ds.cpp
@@ -152,13 +152,13 @@ template <int k, class T, int out> static void BM(benchmark::State &state) {
   BENCHMARK_TEMPLATE(BM, 512, name, out);                                      \
   BENCHMARK_TEMPLATE(BM, 1024, name, out);
 
-test(digest::ds::Naive, 0);
-test(digest::ds::Naive2, 1);
-test(digest::ds::MonoQueue, 2);
-test(digest::ds::SegmentTree, 3);
-test(digest::ds::Set, 4);
-test2(digest::ds::Adaptive, 5);
-test2(digest::ds::Adaptive64, 6);
+test(digest::ds::Naive, 0)
+test(digest::ds::Naive2, 1)
+test(digest::ds::MonoQueue, 2)
+test(digest::ds::SegmentTree, 3)
+test(digest::ds::Set, 4)
+test2(digest::ds::Adaptive, 5)
+test2(digest::ds::Adaptive64, 6)
 
 int main(int argc, char **argv) {
   setupInput();


### PR DESCRIPTION
This removes some redundant semicolons and thereby avoids a compiler error (with -pedantic) in g++ v10.